### PR TITLE
chore: require node 20+

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "standard-version": "latest"
   },
   "engines": {
-    "node": ">= 18"
+    "node": ">= 20"
   },
   "files": [
     "bin",


### PR DESCRIPTION
The `styleText` function of `node:util` is only available in v20+.

https://nodejs.org/api/util.html#utilstyletextformat-text-options